### PR TITLE
Update PmdPlugin defaults

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=io.soffa.gradle
-version=2.3.2
+version=2.3.3
 
 

--- a/src/main/groovy/io/soffa/tools/gradle/qa/PmdPlugin.groovy
+++ b/src/main/groovy/io/soffa/tools/gradle/qa/PmdPlugin.groovy
@@ -29,6 +29,7 @@ class PmdPlugin implements Plugin<Project> {
         <exclude name="JUnitAssertionsShouldIncludeMessage" />
         <exclude name="JUnitTestsShouldIncludeAssert" />
         <exclude name="AvoidUsingHardCodedIP" />
+        <exclude name="GuardLogStatement" />
 
     </rule>
     <rule ref="category/java/codestyle.xml">
@@ -47,6 +48,7 @@ class PmdPlugin implements Plugin<Project> {
         <exclude name="ShortMethodName"/>
         <exclude name="LinguisticNaming"/>
         <exclude name="UnnecessaryFullyQualifiedName"/>
+        <exclude name="UseExplicitTypes"/>
     </rule>
     
     <rule ref="category/java/codestyle.xml/ClassNamingConventions">
@@ -73,6 +75,7 @@ class PmdPlugin implements Plugin<Project> {
         <exclude name="TooManyFields"/>
         <exclude name="TooManyMethods"/>
         <exclude name="CouplingBetweenObjects"/>
+        <exclude name="CognitiveComplexity"/>
     </rule>
     
     <rule ref="category/java/design.xml/CyclomaticComplexity">
@@ -94,6 +97,8 @@ class PmdPlugin implements Plugin<Project> {
         <exclude name="AssignmentInOperand"/>
         <exclude name="UseLocaleWithCaseConversions"/>
         <exclude name="AvoidInstanceofChecksInCatchClause"/>
+        <exclude name="ReturnEmptyCollectionRatherThanNull"/>
+        <exclude name="AvoidLiteralsInIfCondition"/>
     </rule>
     <rule ref="category/java/multithreading.xml">
         <exclude name="DoNotUseThreads" />


### PR DESCRIPTION
I've excluded the following PMD rules from the default config due to the complexity of fixing them and their perceived lack of necessity in our projects:

1. [GuardLogStatement](https://docs.pmd-code.org/pmd-doc-7.1.0/pmd_rules_java_bestpractices.html#guardlogstatement)

2. [UseExplicitTypes](https://docs.pmd-code.org/pmd-doc-7.1.0/pmd_rules_java_codestyle.html#useexplicittypes)

3. [CognitiveComplexity](https://docs.pmd-code.org/pmd-doc-7.1.0/pmd_rules_java_design.html#cognitivecomplexity)

4. [ReturnEmptyCollectionRatherThanNull](https://docs.pmd-code.org/pmd-doc-7.1.0/pmd_rules_java_errorprone.html#returnemptycollectionratherthannull)

5. [AvoidLiteralsInIfCondition](https://docs.pmd-code.org/pmd-doc-7.1.0/pmd_rules_java_errorprone.html#avoidliteralsinifcondition)

These rules are either tricky to change or not essential for our code quality.
Please refer to the linked documentation for more details if needed.